### PR TITLE
Dependent JugglingDB version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "jugglingdb": "latest",
+    "jugglingdb": ">= 0.2.0",
     "mysql": ">= 2.0.0-alpha3"
   },
   "devDependencies": {


### PR DESCRIPTION
Since version jugglingdb >= 0.2.0 is required, it should be specified in the package.json. This prevents some npm warnings at install time as well.
