### PR TITLE
Since there's no timeout param to mocha test frequently fail somewhat randomly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ## TESTS
 
 TESTER = ./node_modules/.bin/mocha
-OPTS = --growl --globals getSchema
+OPTS = --growl --globals getSchema --timeout 15000
 TESTS = test/*.test.js
 
 test:


### PR DESCRIPTION
At least on my rather sad dev box many mysql ops (particularly creating tables) can take quite a bit longer than 2 seconds. Accordingly I've added the mocha '--timeout' parameter and set it to 15000, which seems to pass consistently on my dev box.
