### PR TITLE
Typo in require statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use it you need `jugglingdb@0.2.x`.
 2. Use:
 
     ```javascript
-        var Schema = require('jugglingbd').Schema;
+        var Schema = require('jugglingdb').Schema;
         var schema = new Schema('mysql', {
             database: 'myapp_test',
             username: 'root'


### PR DESCRIPTION
Hi there,

I fixed a typo in the require statement (it was require('juggleBD')).

I've lost a few minutes figuring out the issue was just a typo and not a node.js config issue, so I thought I might as well prevent people from doing the same :)

Cheers, and thanks for the awesome package!

Fabien Allanic
