### PR TITLE
Support for Enum type in MySQL adapter. Requires patch to mainline JDB.

### DIFF
--- a/lib/enumFactory.js
+++ b/lib/enumFactory.js
@@ -1,36 +1,33 @@
-function Enum() {
+var EnumFactory = function() {
     if(arguments.length > 0){
+        var Enum = function Enum(arg){
+            if(typeof arg === 'number' && arg % 1 == 0) {
+                return Enum._values[arg];
+            } else if(Enum[arg]){
+                return Enum[arg]
+            } else if (Enum._values.indexOf(arg) !== -1 ) {
+                return arg;
+            } else if (arg === null) {
+                return null;
+            } else {
+                return '';
+            }
+        };
         var dxList = [];
         dxList.push(''); // Want empty value to be at index 0 to match MySQL Enum values and MySQL non-strict behavior.
         for(var arg in arguments){
             arg = String(arguments[arg]);
-            Object.defineProperty(this, arg.toUpperCase(), {configurable: false, enumerable: true, value: arg, writable: false});
+            Object.defineProperty(Enum, arg.toUpperCase(), {configurable: false, enumerable: true, value: arg, writable: false});
             dxList.push(arg);
         }
-        Object.defineProperty(this, '_values', {configurable: false, enumerable: false, value: dxList, writable: false});
-        Object.defineProperty(this, '_string', {configurable: false, enumerable: false, value: stringified(this), writable: false});
-        Object.freeze(this);
-        return this;
+        Object.defineProperty(Enum, '_values', {configurable: false, enumerable: false, value: dxList, writable: false});
+        Object.defineProperty(Enum, '_string', {configurable: false, enumerable: false, value: stringified(Enum), writable: false});
+        Object.freeze(Enum);
+        return Enum;
     } else {
-        throw "No arguments - can't create Enum.";
+        throw "No arguments - could not create Enum.";
     }
 };
-Object.defineProperty(Enum.prototype, 'name', {configurable: false, enumerable: false, value: 'Enum', writable: false});
-
-
-var EnumFactory = (function() {
-    function FakeEnumConstructor(args) {
-        return Enum.apply(this, args);
-    }
-    
-    FakeEnumConstructor.prototype = Enum.prototype;
-
-    return function() {
-        var returnObject = new FakeEnumConstructor(arguments);
-        returnObject.constructor = Enum.constructor;
-        return returnObject;
-    }
-})();
 
 function stringified(anEnum) {
     var s = []; 
@@ -43,7 +40,7 @@ function stringified(anEnum) {
 }
 
 exports.EnumFactory = EnumFactory;
-exports.Enum = Enum;
+
 
 
 

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -3,7 +3,7 @@
  */
 var mysql = require('mysql');
 var jdb = require('jugglingdb');
-var Enums = require('./enumFactory');
+var EnumFactory = require('./enumFactory').EnumFactory;
 
 
 exports.initialize = function initializeSchema(schema, callback) {
@@ -61,10 +61,8 @@ exports.initialize = function initializeSchema(schema, callback) {
     // MySQL specific column types
     schema.constructor.registerType(function Point() {});
 
-    schema.EnumFactory = Enums.EnumFactory; // factory for Enums
-    schema.Enum = Enums.Enum; // constructor for Enums
+    schema.EnumFactory = EnumFactory; // factory for Enums. Note that currently Enums can not be registered.
     
-    schema.constructor.registerType(Enums.Enum);
     
 };
 
@@ -213,6 +211,7 @@ MySQL.prototype.toDatabase = function (prop, val) {
         return '"' + dateToMysql(val) + '"';
     }
     if (prop.type.name == "Boolean") return val ? 1 : 0;
+    if (typeof prop.type === 'function') return this.client.escape(prop.type(val));
     return this.client.escape(val.toString());
 };
 

--- a/test/datatypes.test.js
+++ b/test/datatypes.test.js
@@ -14,6 +14,17 @@ describe('MySQL specific datatypes', function() {
         });
     });
     
+    it('An enum should parse itself', function(done) {
+        assert.equal(ANIMAL_ENUM.CAT, ANIMAL_ENUM('cat'));
+        assert.equal(ANIMAL_ENUM.CAT, ANIMAL_ENUM('CAT'));
+        assert.equal(ANIMAL_ENUM.CAT, ANIMAL_ENUM(2));
+        assert.equal(ANIMAL_ENUM.CAT, 'cat');
+        assert.equal(ANIMAL_ENUM(null), null);
+        assert.equal(ANIMAL_ENUM(''), '');
+        assert.equal(ANIMAL_ENUM(0), '');
+        done();
+    });
+    
     it('should create a model instance with Enums', function(done) {
        var em = EnumModel.create({animal: ANIMAL_ENUM.CAT, condition: 'sleepy', mood: 'happy'}, function(err, obj) {
             assert.ok(!err);
@@ -57,7 +68,7 @@ function setup(done) {
     EnumModel = db.define('EnumModel', {
         animal: { type: ANIMAL_ENUM, null: false },
         condition: { type: db.EnumFactory('hungry', 'sleepy', 'thirsty') },
-        mood: { type: new db.Enum('angry', 'happy', 'sad') }
+        mood: { type: db.EnumFactory('angry', 'happy', 'sad') }
     });
 
     blankDatabase(db, done);


### PR DESCRIPTION
(See pull request: https://github.com/1602/jugglingdb/pull/296.)

After this there are several ways to use Enum with the adapter as shown in datatypes.test.js.
