### PR TITLE
Fixes boolean conversion when fetching data from database

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -229,7 +229,7 @@ MySQL.prototype.fromDatabase = function (model, data) {
                 val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
                 break;
                 case 'Boolean':
-                val = new Boolean(val);
+                val = Boolean(val);
                 break;
             }
         }


### PR DESCRIPTION
The data was an empty object, since:

```
$ node
> var val = new Boolean(true);
> console.log(val);
{}
> val = Boolean(true);
> console.log(val);
true
```

Cf: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Description
