### PR TITLE
add a .values property to Enums in order to iterate over the non-blank values

### DIFF
--- a/lib/enumFactory.js
+++ b/lib/enumFactory.js
@@ -20,6 +20,7 @@ var EnumFactory = function() {
             Object.defineProperty(Enum, arg.toUpperCase(), {configurable: false, enumerable: true, value: arg, writable: false});
             dxList.push(arg);
         }
+        Object.defineProperty(Enum, 'values', {configurable: false, enumerable: false, value: dxList.slice(1), writable: false});
         Object.defineProperty(Enum, '_values', {configurable: false, enumerable: false, value: dxList, writable: false});
         Object.defineProperty(Enum, '_string', {configurable: false, enumerable: false, value: stringified(Enum), writable: false});
         Object.freeze(Enum);


### PR DESCRIPTION
leaves out the blank value from line 17

allows for easily iterating over the values, for populating a <select> list for example
