### PR TITLE
optional keepAlive configuration param

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -32,6 +32,12 @@ exports.initialize = function initializeSchema(schema, callback) {
         charset: s.collation.toUpperCase(), // Correct by docs despite seeming odd.
         supportBigNumbers: s.supportBigNumbers
     });
+    
+    if (s.keepAlive) {
+    	setInterval(function() {
+    		schema.client.query('select 1');
+    	}, s.keepAlive);
+    }
 
     schema.client.on('error', function (err) {
         schema.emit('error', err);


### PR DESCRIPTION
allow users to specify an optional keepAlive parameter that will issue the query 'select 1' every keepAlive milliseconds so the schema-maintained connection does not get closed due to the MySQL server's idle connection timeout
