### PR TITLE
allow for specifying an offset without a limit

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -258,7 +258,7 @@ MySQL.prototype.all = function all(model, filter, callback) {
             sql += ' ' + buildOrderBy(filter.order);
         }
 
-        if (filter.limit) {
+        if (filter.limit || filter.skip) {
             sql += ' ' + buildLimit(filter.limit, filter.skip || 0);
         }
 
@@ -355,7 +355,7 @@ MySQL.prototype.all = function all(model, filter, callback) {
     }
 
     function buildLimit(limit, offset) {
-        return 'LIMIT ' + (offset ? (offset + ', ' + limit) : limit);
+        return 'LIMIT ' + (offset ? (offset + ', ' + (limit || Math.pow(2,53))) : limit);
     }
 
 };


### PR DESCRIPTION
offset can now be specified and used without having to specify a limit

from http://dev.mysql.com/doc/refman/5.5/en/select.html

To retrieve all rows from a certain offset up to the end of the result set, you can use some large number for the second parameter. This statement retrieves all rows from the 96th row to the last:

SELECT \* FROM tbl LIMIT 95,18446744073709551615;
