### PR TITLE
Adapter attempts to reconnect in 6 not 60 seconds.

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -36,7 +36,7 @@ function initializeConnection(connection, schema, callback) {
             if (err) {
                 console.log('connection.connect err', err);
                 console.log('will reconnect in 60 secs');
-                setTimeout(schema.adapter.connect.bind(schema.adapter, callback), 6000);
+                setTimeout(schema.adapter.connect.bind(schema.adapter, callback), 60000);
                 return;
             }
             callback();


### PR DESCRIPTION
The log message says that the MySQL adapter will attempt to reconnect after 60 seconds, but the code was reconnecting in 6 seconds.  This change adjusts the `setTimeout` call to 60 seconds.